### PR TITLE
fix: remove ESBuildPlugin import.

### DIFF
--- a/packages/craco-esbuild/package.json
+++ b/packages/craco-esbuild/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@svgr/webpack": "^5.5.0",
     "esbuild-jest": "0.5.0",
-    "esbuild-loader": "^2.9.2"
+    "esbuild-loader": "^2.10.0"
   },
   "devDependencies": {
     "@craco/craco": "6.1.1",

--- a/packages/craco-esbuild/src/index.js
+++ b/packages/craco-esbuild/src/index.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const { loaderByName, removeLoaders, addAfterLoader } = require('@craco/craco');
-const { ESBuildPlugin, ESBuildMinifyPlugin } = require('esbuild-loader');
+const { ESBuildMinifyPlugin } = require('esbuild-loader');
 
 module.exports = {
   /**
@@ -55,8 +55,6 @@ module.exports = {
             target: 'es2015',
           }
     );
-
-    webpackConfig.plugins.push(new ESBuildPlugin());
 
     return webpackConfig;
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5206,7 +5206,7 @@ __metadata:
     "@craco/craco": 6.1.1
     "@svgr/webpack": ^5.5.0
     esbuild-jest: 0.5.0
-    esbuild-loader: ^2.9.2
+    esbuild-loader: ^2.10.0
     react-scripts: 4.0.2
   peerDependencies:
     "@craco/craco": ^5.5.0 || ^6.0.0
@@ -6389,28 +6389,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-loader@npm:^2.9.2":
-  version: 2.9.2
-  resolution: "esbuild-loader@npm:2.9.2"
+"esbuild-loader@npm:^2.10.0":
+  version: 2.10.0
+  resolution: "esbuild-loader@npm:2.10.0"
   dependencies:
-    esbuild: ^0.8.42
+    esbuild: ^0.9.2
     joycon: ^2.2.5
     json5: ^2.2.0
     loader-utils: ^2.0.0
-    type-fest: ^0.20.2
+    type-fest: ^0.21.3
     webpack-sources: ^2.2.0
   peerDependencies:
     webpack: ^4.40.0 || ^5.0.0
-  checksum: a1251dab1ed72f68ce9b50a2b58ffef83594627f1bbf8fc53a098525166d1413f22374eeb966bac2848bc61fbf9f593f170c44e23786ae38f64ff5e5a5ff6724
+  checksum: 9f8f2a9e95fb71cbcdaaca59ff6cad8a6a9ac2f1eb5347821e8f4866ffdd30ada8a89fa536fa5eb841a0babf4c3ab276d59dcfe0641c8cff51147edfe0b84be9
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.8.42":
-  version: 0.8.43
-  resolution: "esbuild@npm:0.8.43"
+"esbuild@npm:^0.9.2":
+  version: 0.9.2
+  resolution: "esbuild@npm:0.9.2"
   bin:
     esbuild: bin/esbuild
-  checksum: 67c5fa711eaf83f763101477b11eb9ab07f6c9a6081ad99ad81d3c8ea4d28ad13f78b533617fdbd0426eeea87fcf8f844adf4d1d21399f96f6e7dbccb029d27c
+  checksum: 443c46b61eeffdd9627205de5759d95ab8f9e0dd08c6f51ba3952830ca248e25d323601bef88de94ff71cde076051316564b0ea5d2177110976a3e6623de3732
   languageName: node
   linkType: hard
 
@@ -15330,10 +15330,10 @@ resolve@1.18.1:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^0.20.2":
-  version: 0.20.2
-  resolution: "type-fest@npm:0.20.2"
-  checksum: 1f887bc6150e632fb772fd28e33c22a4ab036c6f484fa9ac2e2115f6cae9d62bba7ca0368e3332b539d85bd2c8391c7bff22ad410abcbc9ab3774d61e250b210
+"type-fest@npm:^0.21.3":
+  version: 0.21.3
+  resolution: "type-fest@npm:0.21.3"
+  checksum: bbe5f5c60e8da4e0b0fe290c31821b10c2fd935768802cd659784cb5e792c7a31bb25a89174d3b42dde3bf8eb9d301ede7456a274c1068280b7698438e250f49
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The following warning is printed in the console with the current configuration of the plugin
```
[esbuild-loader] ESBuildPlugin is no longer required for usage and will be removed in the next major release. Please refer to the docs and release notes for more info.
```

This PR removes the ESBuildPlugin, since it will not be needed anymore and thus eliminates the warning. I furthermore have bumped the esbuild-loader version to the latest.