### PR TITLE
Added skipJest option

### DIFF
--- a/packages/craco-esbuild/README.md
+++ b/packages/craco-esbuild/README.md
@@ -56,7 +56,7 @@ You can configure the options of the plugin by passing an `options` object.
 - `esbuildLoaderOptions`: customise the options passed down to the `esbuild` loader. _Note: This will be used only by webpack_
 - `includePaths`: include external directories in loader.
 - `enableSvgr`: enable the svgr webpack plugin. SVGs are loaded as separate files by default. Enabling this options allow you to import SVGs as React components. See [CRA documentation](https://create-react-app.dev/docs/adding-images-fonts-and-files/#adding-svgs) for more detailed explanation.
-- `skipJest`: Avoid using `esbuild-jest` for jest configuration. Could be useful to avoid compatibility issues with transpiling tests.
+- `skipEsbuildJest`: Avoid using `esbuild-jest` for jest configuration. Could be useful to avoid compatibility issues with transpiling tests.
 
 For example add this configuration to your `craco.config.js` configuration file:
 
@@ -75,7 +75,7 @@ module.exports = {
           loader: 'jsx', // Set the value to 'tsx' if you use typescript 
           target: 'es2015',
         },
-        skipJest: true, // Optional. If you want to avoid modifying jest configuration
+        skipEsbuildJest: false, // Optional. Set to true if you want to use babel for jest tests
       },
     },
   ],

--- a/packages/craco-esbuild/README.md
+++ b/packages/craco-esbuild/README.md
@@ -56,6 +56,7 @@ You can configure the options of the plugin by passing an `options` object.
 - `esbuildLoaderOptions`: customise the options passed down to the `esbuild` loader. _Note: This will be used only by webpack_
 - `includePaths`: include external directories in loader.
 - `enableSvgr`: enable the svgr webpack plugin. SVGs are loaded as separate files by default. Enabling this options allow you to import SVGs as React components. See [CRA documentation](https://create-react-app.dev/docs/adding-images-fonts-and-files/#adding-svgs) for more detailed explanation.
+- `skipJest`: Avoid using `esbuild-jest` for jest configuration. Could be useful to avoid compatibility issues with transpiling tests.
 
 For example add this configuration to your `craco.config.js` configuration file:
 
@@ -74,6 +75,7 @@ module.exports = {
           loader: 'jsx', // Set the value to 'tsx' if you use typescript 
           target: 'es2015',
         },
+        skipJest: true, // Optional. If you want to avoid modifying jest configuration
       },
     },
   ],

--- a/packages/craco-esbuild/src/index.js
+++ b/packages/craco-esbuild/src/index.js
@@ -63,7 +63,7 @@ module.exports = {
    * To process the js/ts files we replace the babel-loader with the esbuild jest loader
    */
   overrideJestConfig: ({ jestConfig, pluginOptions }) => {
-    if (pluginOptions && pluginOptions.skipJest) return jestConfig;
+    if (pluginOptions && pluginOptions.skipEsbuildJest) return jestConfig;
 
     const options = {
       loaders: {

--- a/packages/craco-esbuild/src/index.js
+++ b/packages/craco-esbuild/src/index.js
@@ -62,7 +62,9 @@ module.exports = {
   /**
    * To process the js/ts files we replace the babel-loader with the esbuild jest loader
    */
-  overrideJestConfig: ({ jestConfig }) => {
+  overrideJestConfig: ({ jestConfig, pluginOptions }) => {
+    if (pluginOptions && pluginOptions.skipJest) return jestConfig;
+
     const options = {
       loaders: {
         '.js': 'jsx',


### PR DESCRIPTION
Related to #30 issue. Until the bug is resolved it can be useful to use speed up with `start` and `build` scripts at least (omitting `test`).