### PR TITLE
feat: add `esbuildJestOptions` to override esbuild-jest's options

### DIFF
--- a/packages/craco-esbuild/README.md
+++ b/packages/craco-esbuild/README.md
@@ -57,6 +57,7 @@ You can configure the options of the plugin by passing an `options` object.
 - `includePaths`: include external directories in loader.
 - `enableSvgr`: enable the svgr webpack plugin. SVGs are loaded as separate files by default. Enabling this options allow you to import SVGs as React components. See [CRA documentation](https://create-react-app.dev/docs/adding-images-fonts-and-files/#adding-svgs) for more detailed explanation.
 - `skipEsbuildJest`: Avoid using `esbuild-jest` for jest configuration. Could be useful to avoid compatibility issues with transpiling tests.
+- `esbuildJestOptions`: customise the [options](https://github.com/aelbore/esbuild-jest#setting-up-jest-config-file-with-transformoptions) passed down to the `esbuild-jest` transformer.
 
 For example add this configuration to your `craco.config.js` configuration file:
 
@@ -75,7 +76,13 @@ module.exports = {
           loader: 'jsx', // Set the value to 'tsx' if you use typescript
           target: 'es2015',
         },
-        skipEsbuildJest: false, // Optional. Set to true if you want to use babel for jest tests
+        skipEsbuildJest: false, // Optional. Set to true if you want to use babel for jest tests,
+        esbuildJestOptions: {
+          loaders: {
+            '.ts': 'ts',
+            '.tsx': 'tsx'
+          }
+        }
       },
     },
   ],

--- a/packages/craco-esbuild/src/index.js
+++ b/packages/craco-esbuild/src/index.js
@@ -65,7 +65,7 @@ module.exports = {
   overrideJestConfig: ({ jestConfig, pluginOptions }) => {
     if (pluginOptions && pluginOptions.skipEsbuildJest) return jestConfig;
 
-    const options = {
+    const defaultEsbuildJestOptions = {
       loaders: {
         '.js': 'jsx',
         '.test.js': 'jsx',
@@ -74,9 +74,12 @@ module.exports = {
       },
     };
 
+    const esbuildJestOptions = (pluginOptions && pluginOptions.esbuildJestOptions) || defaultEsbuildJestOptions;
+
+
     // Replace babel transform with esbuild
     // babelTransform is first transformer key
-    /* 
+    /*
     transform:
       {
         '^.+\\.(js|jsx|mjs|cjs|ts|tsx)$': 'node_modules\\react-scripts\\config\\jest\\babelTransform.js',
@@ -87,7 +90,7 @@ module.exports = {
     const babelKey = Object.keys(jestConfig.transform)[0];
 
     // We replace babelTransform and add loaders to esbuild-jest
-    jestConfig.transform[babelKey] = [require.resolve('esbuild-jest'), options];
+    jestConfig.transform[babelKey] = [require.resolve('esbuild-jest'), esbuildJestOptions];
 
     // Adds loader to all other transform options (2 in this case: cssTransform and fileTransform)
     // Reason for this is esbuild-jest plugin. It considers only loaders or other options from the last transformer
@@ -105,9 +108,9 @@ module.exports = {
         Array.isArray(jestConfig.transform[key]) &&
         jestConfig.transform[key].length === 1
       ) {
-        jestConfig.transform[key].push(options);
+        jestConfig.transform[key].push(esbuildJestOptions);
       } else {
-        jestConfig.transform[key] = [jestConfig.transform[key], options];
+        jestConfig.transform[key] = [jestConfig.transform[key], esbuildJestOptions];
       }
     });
 


### PR DESCRIPTION
Add `esbuildJestOptions` to override [`esbuild-jest`'s options](https://github.com/aelbore/esbuild-jest#setting-up-jest-config-file-with-transformoptions)

Fixes #33