### PR TITLE
feat!: add esbuild css minification 

### DIFF
--- a/packages/craco-esbuild/README.md
+++ b/packages/craco-esbuild/README.md
@@ -80,7 +80,7 @@ module.exports = {
         esbuildMinimizerOptions: { // Optional. Defaults to:
           target: 'es2015',
           css: true, // if true, OptimizeCssAssetsWebpackPlugin will also be replaced by esbuild.
-        }
+        },
         skipEsbuildJest: false, // Optional. Set to true if you want to use babel for jest tests,
         esbuildJestOptions: {
           loaders: {

--- a/packages/craco-esbuild/README.md
+++ b/packages/craco-esbuild/README.md
@@ -54,6 +54,7 @@ To use `craco` instead of `react-scripts` to manage our application, edit the `s
 You can configure the options of the plugin by passing an `options` object.
 
 - `esbuildLoaderOptions`: customise the options passed down to the `esbuild` loader. _Note: This will be used only by webpack_
+- `esbuildMinimizerOptions`: customise the options passed down to `ESBuildMinifyPlugin`. _Note: This will be used only by webpack_
 - `includePaths`: include external directories in loader.
 - `enableSvgr`: enable the svgr webpack plugin. SVGs are loaded as separate files by default. Enabling this options allow you to import SVGs as React components. See [CRA documentation](https://create-react-app.dev/docs/adding-images-fonts-and-files/#adding-svgs) for more detailed explanation.
 - `skipEsbuildJest`: Avoid using `esbuild-jest` for jest configuration. Could be useful to avoid compatibility issues with transpiling tests.
@@ -72,10 +73,14 @@ module.exports = {
       options: {
         includePaths: ['/external/dir/with/components'], // Optional. If you want to include components which are not in src folder
         enableSvgr: true, // Optional.
-        esbuildLoaderOptions: {
+        esbuildLoaderOptions: { // Optional. Defaults to auto-detect loader.
           loader: 'jsx', // Set the value to 'tsx' if you use typescript
           target: 'es2015',
         },
+        esbuildMinimizerOptions: { // Optional. Defaults to:
+          target: 'es2015',
+          css: true, // if true, OptimizeCssAssetsWebpackPlugin will also be replaced by esbuild.
+        }
         skipEsbuildJest: false, // Optional. Set to true if you want to use babel for jest tests,
         esbuildJestOptions: {
           loaders: {

--- a/packages/craco-esbuild/src/index.js
+++ b/packages/craco-esbuild/src/index.js
@@ -2,6 +2,16 @@ const fs = require('fs');
 const { loaderByName, removeLoaders, addAfterLoader } = require('@craco/craco');
 const { ESBuildMinifyPlugin } = require('esbuild-loader');
 
+const removeMinimizer = (webpackConfig, name) => {
+  const idx = webpackConfig.optimization.minimizer.findIndex(m => m.constructor.name === name)
+  webpackConfig.optimization.minimizer.splice(idx, 1);
+}
+
+const replaceMinimizer = (webpackConfig, name, minimizer) => {
+  const idx = webpackConfig.optimization.minimizer.findIndex(m => m.constructor.name === name)
+  webpackConfig.optimization.minimizer.splice(idx, 1, minimizer);
+}
+
 module.exports = {
   /**
    * To process the js/ts files we replace the babel-loader with the esbuild-loader
@@ -48,14 +58,17 @@ module.exports = {
     removeLoaders(webpackConfig, loaderByName('babel-loader'));
 
     // Replace terser with esbuild
-    webpackConfig.optimization.minimizer[0] = new ESBuildMinifyPlugin(
-      pluginOptions && pluginOptions.esbuildLoaderOptions
-        ? pluginOptions.esbuildLoaderOptions
-        : {
-            target: 'es2015',
-          }
-    );
-
+    const minimizerOptions = pluginOptions?.esbuildMinimizerOptions || {
+      target: 'es2015',
+      css: true,
+    };
+    replaceMinimizer(webpackConfig, 'TerserPlugin',  new ESBuildMinifyPlugin(
+      minimizerOptions
+    ));    
+    // remove the css OptimizeCssAssetsWebpackPlugin
+    if (minimizerOptions.css) {
+      removeMinimizer(webpackConfig, "OptimizeCssAssetsWebpackPlugin");
+    }
     return webpackConfig;
   },
 


### PR DESCRIPTION
# Motivation
Esbuild can also take care of css minification and it is also very fast at it.
This PR enables support for configuring the minifiers separately and replacing the default CRA CSS minifier. 

## WARNING
* Defaults to using esbuild as css minifier
* Slight change in API. The loader options are not passed to the minifier options anymore.

See code and #35 for more information.
