### PR TITLE
fix: compatability with node 12

### DIFF
--- a/packages/craco-esbuild/src/index.js
+++ b/packages/craco-esbuild/src/index.js
@@ -62,7 +62,7 @@ module.exports = {
     removeLoaders(webpackConfig, loaderByName('babel-loader'));
 
     // Replace terser with esbuild
-    const minimizerOptions = pluginOptions?.esbuildMinimizerOptions || {
+    const minimizerOptions = (pluginOptions || {}).esbuildMinimizerOptions || {
       target: 'es2015',
       css: true,
     };


### PR DESCRIPTION
https://github.com/pradel/create-react-app-esbuild/pull/36 added a line with optional chaining which is only [available since Node 14](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining#browser_compatibility):
https://github.com/pradel/create-react-app-esbuild/blob/d478ad10a38718666cfeb223bcae3933844ee0a7/packages/craco-esbuild/src/index.js#L65
That fails users of node12 (especially CI systems).

This small change replaces that line with a syntax that is compatible with node 12 too.

resolves #39 