### PR TITLE
feat: replace minifier only when used

### DIFF
--- a/packages/craco-esbuild/src/index.js
+++ b/packages/craco-esbuild/src/index.js
@@ -13,7 +13,7 @@ const replaceMinimizer = (webpackConfig, name, minimizer) => {
   const idx = webpackConfig.optimization.minimizer.findIndex(
     (m) => m.constructor.name === name
   );
-  webpackConfig.optimization.minimizer.splice(idx, 1, minimizer);
+  idx > -1 && webpackConfig.optimization.minimizer.splice(idx, 1, minimizer);
 };
 
 module.exports = {


### PR DESCRIPTION
I added a small test before replacing the minimizer in order to replace it only when it is actually used.

On my setup I currently have an other craco override that remove minification in some cases to speed up the build time.
With this change, minification remains disabled as expected.