### PR TITLE
feat: add `svgrOptions` to customize svgr plugin behavior

### DIFF
--- a/packages/craco-esbuild/README.md
+++ b/packages/craco-esbuild/README.md
@@ -57,6 +57,7 @@ You can configure the options of the plugin by passing an `options` object.
 - `esbuildMinimizerOptions`: customise the options passed down to `ESBuildMinifyPlugin`. _Note: This will be used only by webpack_
 - `includePaths`: include external directories in loader.
 - `enableSvgr`: enable the svgr webpack plugin. SVGs are loaded as separate files by default. Enabling this options allow you to import SVGs as React components. See [CRA documentation](https://create-react-app.dev/docs/adding-images-fonts-and-files/#adding-svgs) for more detailed explanation.
+- `svgrOptions`: customise the options passed down to the `svgr` loader.
 - `skipEsbuildJest`: Avoid using `esbuild-jest` for jest configuration. Could be useful to avoid compatibility issues with transpiling tests.
 - `esbuildJestOptions`: customise the [options](https://github.com/aelbore/esbuild-jest#setting-up-jest-config-file-with-transformoptions) passed down to the `esbuild-jest` transformer.
 
@@ -73,6 +74,10 @@ module.exports = {
       options: {
         includePaths: ['/external/dir/with/components'], // Optional. If you want to include components which are not in src folder
         enableSvgr: true, // Optional.
+        svgrOptions: {
+          // Optional. is enableSvgr set to true, used as options for svgr
+          icon: true,
+        },
         esbuildLoaderOptions: {
           // Optional. Defaults to auto-detect loader.
           loader: 'jsx', // Set the value to 'tsx' if you use typescript

--- a/packages/craco-esbuild/src/index.js
+++ b/packages/craco-esbuild/src/index.js
@@ -36,7 +36,10 @@ module.exports = {
     if (pluginOptions && pluginOptions.enableSvgr) {
       webpackConfig.module.rules.unshift({
         test: /\.svg$/,
-        use: ['@svgr/webpack'],
+        use: [{
+          loader: '@svgr/webpack',
+          options: (pluginOptions && pluginOptions.svgrOptions) || {}
+        }],
       });
     }
 


### PR DESCRIPTION
I needed to be able to pass svgr options (for me to be able to set the icon option to true) : 

```
plugins: [
      {
        plugin: CracoEsbuildPlugin,
        options: {
          enableSvgr: true,
          svgrOptions: {
            icon: true,
          },
        },
      },
    ],
```

Closes #31