### PR TITLE
fix: properly include craco 7.0.0-alpha versions for cra5 support

### DIFF
--- a/.changeset/cyan-chairs-wash.md
+++ b/.changeset/cyan-chairs-wash.md
@@ -1,0 +1,5 @@
+---
+'craco-esbuild': patch
+---
+
+Include @craco/craco@7.0.0-alpha.* versions in peerDependencies

--- a/packages/craco-esbuild/package.json
+++ b/packages/craco-esbuild/package.json
@@ -9,7 +9,7 @@
     "src"
   ],
   "peerDependencies": {
-    "@craco/craco": "^6.0.0 || ^7.0.0",
+    "@craco/craco": "^6.0.0 || ^7.0.0 || ^7.0.0-alpha",
     "react-scripts": "^5.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
related #54, #57

it appears that a recent fix included `^7.0.0` but that doesn't match the semver `7.0.0-alpha.*`
all of craco's 7.0.0 versions are in alpha  so we still have issues on cra5 without `--legacy-peer-deps`

[this resolves this issue by ensuring the range matches the alpha semver](https://stackblitz.com/edit/node-uscu7b?file=index.js)
![image](https://user-images.githubusercontent.com/29434693/187009574-ac2a3b4d-6664-4882-967b-085c01f38490.png)
